### PR TITLE
feat: dso-904. policy - allowed TF providers list extended

### DIFF
--- a/policy/approved_providers.rego
+++ b/policy/approved_providers.rego
@@ -5,6 +5,9 @@ deny[msg] {
     resource_change.provider_name != "registry.terraform.io/hashicorp/aws"
     resource_change.provider_name != "registry.terraform.io/hashicorp/random"
     resource_change.provider_name != "registry.terraform.io/hashicorp/azurerm"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/google"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/local"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/null"
 
     msg := sprintf("Provider is not allowed: %s", [resource_change.provider_name])
 }


### PR DESCRIPTION
- 'local' and 'null' providers are or will be widely used
- as google cloud provider too
- example of affected module - https://github.com/nexient-llc/tf-aws-wrapper_module-lambda_function