### PR TITLE
feat: dso-1113. terratests. new flavor introduced - readonly

### DIFF
--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -11,6 +11,10 @@ FIND ?= find
 # Variables
 
 GO_TEST_DIRECTORIES ?= tests
+GO_TEST_TIMEOUT ?= 30m
+GO_TEST_READONLY_DIRECTORY ?= post_deploy_functional_readonly
+TEST_RUN_ONLY_READONLY = #intentionally empty
+TEST_RUN_EXCLUDE_READONLY = -v
 GOLANGCI_LINT_CONFIG ?= .golangci.yaml
 DISABLE_MAKE_CHECK_LINT ?= false
 
@@ -23,9 +27,9 @@ define go_lint
 
 endef
 
-# Check for Go files. If they exist, run tests.
+# Check for Go files. If they exist, run tests. Either runs only readonly tests(default) or tests except readonly ones
 define go_test
-	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
+	$(FIND) $(1)/ -name '*.go' |$(GREP) $(2) $(GO_TEST_READONLY_DIRECTORY) | $(GREP) -q '\.go' || exit 0; $(GO) test -v -count=1 -timeout=$(GO_TEST_TIMEOUT) $$($(GO) list ./$(1)/...|$(GREP) $(2)  $(GO_TEST_READONLY_DIRECTORY)) ;
 
 endef
 
@@ -37,7 +41,10 @@ go/lint :
 
 .PHONY: go/test
 go/test :
-	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir)))
+	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir),$(TEST_RUN_EXCLUDE_READONLY)))
+
+go/readonly_test:
+	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir),$(TEST_RUN_ONLY_READONLY)))
 
 # This is a special declaration
 # Whenever check is defined, it must be defined with a ::


### PR DESCRIPTION
- Nondestructive post deployment high env regression test - tests/post_deploy_functional_readonly
- - ref https://github.com/nexient-llc/tf-caf-terratest-common
- test timeout configurable - infra tests can take loooong time
- golang test caching disabled
- - Bc. golang does not know about changes in terraform code and it may render test useless

P.S.
After merging this, those lines we should clean out from TF modules repos Makefiles, if exists there
```
go/readonly_test:
	find tests/ -name '*.go' |grep  post_deploy_functional_readonly| grep -q '\.go' || exit 0; go test -v -count=1 -p=1 -timeout=90m $$(go list ./tests/...|grep post_deploy_functional_readonly) ;

go/test:
	find tests/ -name '*.go' |grep -v post_deploy_functional_readonly| grep -q '\.go' || exit 0; go test -v -count=1 -p=1 -timeout=90m $$(go list ./tests/...|grep -v post_deploy_functional_readonly) ;
```